### PR TITLE
Bug fix

### DIFF
--- a/qa_consistency/dataset_utils.py
+++ b/qa_consistency/dataset_utils.py
@@ -77,7 +77,7 @@ def generate_implication_vqa(original_dataset, original_preds_path, implication_
                 'question_type': source_map[source]
             }
             new_dataset.questions[new_idx] = {
-                'question': question,
+                'question': q,
                 'image_id': image_id,
                 'question_id': new_idx
             }


### PR DESCRIPTION
@marcotcr 
I think there is a bug in qa_consistency.dataset_utils.py

In line 79, while adding question to the new_dataset, you're using original question instead of the  implied question.

` new_dataset.questions[new_idx] = {
                'question': question,
                'image_id': image_id,
                'question_id': new_idx
            }`

which should be instead

` new_dataset.questions[new_idx] = {
                'question': q,
                'image_id': image_id,
                'question_id': new_idx
            }`